### PR TITLE
chore: fixed macos build

### DIFF
--- a/Mil.Paperwork.UI/Mil.Paperwork.UI.csproj
+++ b/Mil.Paperwork.UI/Mil.Paperwork.UI.csproj
@@ -15,9 +15,12 @@
 
   <PropertyGroup Condition="$(OperatingSystem) == 'maccatalyst' or $(RuntimeIdentifier.StartsWith('osx'))">
     <UseLocalAppHost>true</UseLocalAppHost>
-    <ApplicationIcon>Assets/temp-logo.icns</ApplicationIcon>
     <ApplicationId>com.vvnikolaiev.mil.paperwork</ApplicationId>
   </PropertyGroup>
+
+  <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('osx'))">
+    <BundleResource Include="Assets\temp-logo.icns" />
+  </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Models\" />


### PR DESCRIPTION
- Updated ExcelDocumentHelper.cs to use platform-specific code paths so GDI+ code only compiles on Windows
- Added application icon as a BundleResource for macOS