### PR TITLE
refactor: apply code conventions across the entire codebase

### DIFF
--- a/Mil.MVVM.Common/MVVM/ObservableItem.cs
+++ b/Mil.MVVM.Common/MVVM/ObservableItem.cs
@@ -19,7 +19,10 @@ namespace Mil.MVVM.Common
 
         protected bool SetProperty<T>(ref T field, T value, [CallerMemberName] string propertyName = null)
         {
-            if (Equals(field, value)) return false;
+            if (Equals(field, value))
+            {
+                return false;
+            }
             field = value;
             NotifyValueChanged(value, propertyName);
             return true;

--- a/Mil.Paperwork.Common/Helpers/ImportHelper.cs
+++ b/Mil.Paperwork.Common/Helpers/ImportHelper.cs
@@ -82,7 +82,10 @@ namespace Mil.Paperwork.Common.Helpers
                     }
 
                     var column = columnsToMap.FirstOrDefault(c => c.Title == attr.Title);
-                    if (column?.SelectedSourceColumn == null) continue;
+                    if (column?.SelectedSourceColumn == null)
+                    {
+                        continue;
+                    }
 
                     if (row.TryGetValue(column.SelectedSourceColumn, out var value) && value != null)
                     {

--- a/Mil.Paperwork.Common/Helpers/SimpleNumberParser.cs
+++ b/Mil.Paperwork.Common/Helpers/SimpleNumberParser.cs
@@ -14,13 +14,18 @@ namespace Mil.Paperwork.Common.Helpers
         public static bool TryParse(string input, out decimal result)
         {
             result = 0m;
-            if (string.IsNullOrWhiteSpace(input)) return false;
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return false;
+            }
 
             string s = input.Trim();
 
             // quick reject: both separators present -> ambiguous
             if (s.IndexOf('.') >= 0 && s.IndexOf(',') >= 0)
+            {
                 return false;
+            }
 
             // remove spaces (common when copying)
             s = s.Replace(" ", string.Empty);
@@ -33,24 +38,36 @@ namespace Mil.Paperwork.Common.Helpers
                 s = s.Substring(1, s.Length - 2).Trim();
             }
 
-            if (s.Length == 0) return false;
+            if (s.Length == 0)
+            {
+                return false;
+            }
 
             // normalize comma to dot if present
             if (s.IndexOf(',') >= 0)
+            {
                 s = s.Replace(',', '.');
+            }
 
             // final simple parse using InvariantCulture (dot as decimal separator)
             if (!decimal.TryParse(s, NumberStyles.Number, CultureInfo.InvariantCulture, out result))
+            {
                 return false;
+            }
 
-            if (parenthesisNegative && result > 0) result = -result;
+            if (parenthesisNegative && result > 0)
+            {
+                result = -result;
+            }
             return true;
         }
 
         public static decimal Parse(string input)
         {
             if (!TryParse(input, out var r))
+            {
                 throw new FormatException($"Invalid numeric input: '{input}'");
+            };
             return r;
         }
     }

--- a/Mil.Paperwork.Domain/DataModels/Parameters/TechnicalStateReportParameters.cs
+++ b/Mil.Paperwork.Domain/DataModels/Parameters/TechnicalStateReportParameters.cs
@@ -16,7 +16,7 @@ namespace Mil.Paperwork.Domain.DataModels.Parameters
 
         public static TechnicalStateReportParameters FromReportData(ITechnicalStateReportData reportData)
         {
-            return new TechnicalStateReportParameters
+            var result = new TechnicalStateReportParameters
             {
                 DocumentDate = reportData.DocumentDate,
                 EventType = reportData.EventType,
@@ -25,6 +25,7 @@ namespace Mil.Paperwork.Domain.DataModels.Parameters
                 OrdenDate = reportData.OrdenDate,
                 Reason = reportData.Reason
             };
+            return result;
         }
     }
 }

--- a/Mil.Paperwork.Domain/DataModels/Parameters/WriteOffPackageParameters.cs
+++ b/Mil.Paperwork.Domain/DataModels/Parameters/WriteOffPackageParameters.cs
@@ -15,7 +15,7 @@ namespace Mil.Paperwork.Domain.DataModels.Parameters
 
         public static WriteOffPackageParameters FromReportData(IWriteOffPackageReportData reportData)
         {
-            return new WriteOffPackageParameters
+            var result = new WriteOffPackageParameters
             {
                 OrdenNumber = reportData.OrdenNumber,
                 OrdenDate = reportData.OrdenDate,
@@ -24,6 +24,7 @@ namespace Mil.Paperwork.Domain.DataModels.Parameters
                 TotalWriteOffSum = ResidualPriceHelper.CalculateTotalReportSum(reportData.Assets, reportData.EventDate, true),
                 Assets = reportData.Assets,
             };
+            return result;
         }
     }
 }

--- a/Mil.Paperwork.Domain/DataModels/ReportData/QualityStateReportData.cs
+++ b/Mil.Paperwork.Domain/DataModels/ReportData/QualityStateReportData.cs
@@ -26,7 +26,7 @@ namespace Mil.Paperwork.Domain.DataModels.ReportData
 
         public static CommonWriteOffReportData FromReportData(ICommonWriteOffReportData reportData)
         {
-            return new CommonWriteOffReportData
+            var result = new CommonWriteOffReportData
             {
                 DocumentDate = reportData.DocumentDate,
                 EventType = reportData.EventType,
@@ -36,6 +36,7 @@ namespace Mil.Paperwork.Domain.DataModels.ReportData
                 Reason = reportData.Reason,
                 Assets = reportData.Assets,
             };
+            return result;
         }
 
         public string GetDestinationPath()

--- a/Mil.Paperwork.Domain/DataModels/ReportData/WriteOffOrderReportData.cs
+++ b/Mil.Paperwork.Domain/DataModels/ReportData/WriteOffOrderReportData.cs
@@ -22,6 +22,9 @@ namespace Mil.Paperwork.Domain.DataModels.ReportData
 
         public string DestinationFolder { get; set; } = string.Empty;
 
-        public string GetDestinationPath() => DestinationFolder;
+        public string GetDestinationPath()
+        {
+            return DestinationFolder;
+        }
     }
 }

--- a/Mil.Paperwork.Domain/Helpers/CoefficientsHelper.cs
+++ b/Mil.Paperwork.Domain/Helpers/CoefficientsHelper.cs
@@ -127,7 +127,8 @@
                     break;
                 }
             }
-            return Math.Round(coefficient, 3);
+            var result = Math.Round(coefficient, 3);
+            return result;
         }
 
         private static int GetExploitationYears(DateTime startDate, DateTime? endDate)

--- a/Mil.Paperwork.Domain/Helpers/ExcelDocumentHelper.cs
+++ b/Mil.Paperwork.Domain/Helpers/ExcelDocumentHelper.cs
@@ -38,12 +38,17 @@ namespace Mil.Paperwork.Domain.Helpers
 
         public static double MeasureTextHeight(string text, ExcelFont font, double width)
         {
-            if (string.IsNullOrEmpty(text)) return 0.0;
+            if (string.IsNullOrEmpty(text))
+            {
+                return 0.0;
+            }
 
             #if WINDOWS
-                return MeasureTextHeightWindows(text, font, width);
+                var result = MeasureTextHeightWindows(text, font, width);
+                return result;
             #else
-                return MeasureTextHeightCrossPlatform(text, font, width);
+                var result = MeasureTextHeightCrossPlatform(text, font, width);
+                return result;
             #endif
         }
 
@@ -59,7 +64,8 @@ namespace Mil.Paperwork.Domain.Helpers
                 var size = graphics.MeasureString(text, drawingFont, pixelWidth, new StringFormat { FormatFlags = StringFormatFlags.MeasureTrailingSpaces });
 
                 // 72 DPI and 96 points per inch. Excel height in points with max of 409 per Excel requirements.
-                return Math.Min(Convert.ToDouble(size.Height) * 72 / 96, 409);
+                var result = Math.Min(Convert.ToDouble(size.Height) * 72 / 96, 409);
+                return result;
             }
         }
 #else
@@ -72,7 +78,8 @@ namespace Mil.Paperwork.Domain.Helpers
             var estimatedHeight = lineCount * fontSize * 1.7; // Add 20% for line spacing
             
             // Excel height in points with max of 409 per Excel requirements
-            return Math.Min(estimatedHeight, 409);
+            var result = Math.Min(estimatedHeight, 409);
+            return result;
         }
 #endif
         public static void MapDataToTheNamedFields(this ExcelWorksheet sheet, Dictionary<string, string> fieldsMap)

--- a/Mil.Paperwork.Domain/Helpers/Handover23ActHelper.cs
+++ b/Mil.Paperwork.Domain/Helpers/Handover23ActHelper.cs
@@ -46,7 +46,8 @@
         public static string GetReasonDocProps(string docNumber, DateTime docDate)
         {
             var numberPart = string.IsNullOrEmpty(docNumber) ? WithoutNumberText : docNumber;
-            return string.Format(DocumentPropsFormat, numberPart, docDate.ToString(ReportHelper.DATE_FORMAT));
+            var result = string.Format(DocumentPropsFormat, numberPart, docDate.ToString(ReportHelper.DATE_FORMAT));
+            return result;
         }
 
     }

--- a/Mil.Paperwork.Domain/Helpers/PathsHelper.cs
+++ b/Mil.Paperwork.Domain/Helpers/PathsHelper.cs
@@ -10,7 +10,8 @@ namespace Mil.Paperwork.Domain.Helpers
         public static string GetTemplatePath(string templateName)
         {
             var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-            return Path.Combine(baseDirectory, TEMPLATES_DIRECTORY, templateName);
+            var result = Path.Combine(baseDirectory, TEMPLATES_DIRECTORY, templateName);
+            return result;
         }
 
         public static string GetDestinationPath(string destinationFolder, int? reportNumber, DateTime reportDate)

--- a/Mil.Paperwork.Domain/Helpers/ReportHelper.cs
+++ b/Mil.Paperwork.Domain/Helpers/ReportHelper.cs
@@ -268,24 +268,45 @@ namespace Mil.Paperwork.Domain.Helpers
         public static string ConvertNumberToWords(int number, NounGender gender)
         {
             if (number == 0)
+            {
                 return Units[gender][0];
+            }
 
             var units = Units[gender];
 
             if (number < 10)
+            {
                 return units[number];
+            }
             else if (number < 20)
+            {
                 return Teens[number - 10];
+            }
             else if (number < 100)
-                return Tens[number / 10] + (number % 10 > 0 ? " " + units[number % 10] : "");
+            {
+                var result = Tens[number / 10] + (number % 10 > 0 ? " " + units[number % 10] : "");
+                return result;
+            }
             else if (number < 1000)
-                return Hundreds[number / 100] + (number % 100 > 0 ? " " + ConvertNumberToWords(number % 100, gender) : "");
+            {
+                var result = Hundreds[number / 100] + (number % 100 > 0 ? " " + ConvertNumberToWords(number % 100, gender) : "");
+                return result;
+            }
             else if (number < 1000000)
-                return ConvertLargeNumberToWords(number, 1000, Thousands, NounGender.Feminine);
+            {
+                var result = ConvertLargeNumberToWords(number, 1000, Thousands, NounGender.Feminine);
+                return result;
+            }
             else if (number < 1000000000)
-                return ConvertLargeNumberToWords(number, 1000000, Millions, NounGender.Masculine);
+            {
+                var result = ConvertLargeNumberToWords(number, 1000000, Millions, NounGender.Masculine);
+                return result;
+            }
             else
-                return ConvertLargeNumberToWords(number, 1000000000, Billions, NounGender.Masculine);
+            {
+                var result = ConvertLargeNumberToWords(number, 1000000000, Billions, NounGender.Masculine);
+                return result;
+            }
         }
 
         public static string GenerateItemsCountText(int count, MeasurementUnitDTO? measurementUnit)
@@ -301,7 +322,8 @@ namespace Mil.Paperwork.Domain.Helpers
 
         public static string GetPriceString(decimal price)
         {
-            return price.ToString("N", PriceNumberFormatInfo);
+            var result = price.ToString("N", PriceNumberFormatInfo);
+            return result;
         }
 
         // TODO: refactor later?
@@ -320,7 +342,8 @@ namespace Mil.Paperwork.Domain.Helpers
                 _ => forms[0],
             };
 
-            return ConvertNumberToWords(quotient, gender) + " " + form + (remainder > 0 ? " " + ConvertNumberToWords(remainder, gender) : "");
+            var result = ConvertNumberToWords(quotient, gender) + " " + form + (remainder > 0 ? " " + ConvertNumberToWords(remainder, gender) : "");
+            return result;
         }
     }
 }

--- a/Mil.Paperwork.Domain/Helpers/WordDocumentHelper.cs
+++ b/Mil.Paperwork.Domain/Helpers/WordDocumentHelper.cs
@@ -32,7 +32,8 @@ namespace Mil.Paperwork.Domain.Helpers
             stream.Write(bytes, 0, bytes.Length);
             stream.Position = 0;
             var wdoc = WordprocessingDocument.Open(stream, isEditable: true);
-            return new WordDocument(stream, wdoc);
+            var result = new WordDocument(stream, wdoc);
+            return result;
         }
 
         public WordTable? GetTable(string tableName)
@@ -40,13 +41,15 @@ namespace Mil.Paperwork.Domain.Helpers
             var table = _body.Descendants<Table>()
                 .FirstOrDefault(t => t.GetFirstChild<TableProperties>()
                                       ?.GetFirstChild<TableCaption>()?.Val?.Value == tableName);
-            return table != null ? new WordTable(table) : null;
+            var result = table != null ? new WordTable(table) : null;
+            return result;
         }
 
         public WordTable? GetTableByIndex(int index)
         {
             var table = _body.Descendants<Table>().ElementAtOrDefault(index);
-            return table != null ? new WordTable(table) : null;
+            var result = table != null ? new WordTable(table) : null;
+            return result;
         }
 
         public void ReplaceField(string fieldName, string? value)
@@ -61,14 +64,19 @@ namespace Mil.Paperwork.Domain.Helpers
                 {
                     var instr = fld.Instruction?.Value ?? string.Empty;
                     var fldParts = instr.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-                    if (!fldParts.Contains("MERGEFIELD") || !fldParts.Contains(cleanName)) continue;
+                    if (!fldParts.Contains("MERGEFIELD") || !fldParts.Contains(cleanName))
+                    {
+                        continue;
+                    }
 
                     var existingRPr = fld.GetFirstChild<Run>()?.GetFirstChild<RunProperties>();
                     fld.Elements<Run>().ToList().ForEach(r => r.Remove());
 
                     var newRun = new Run();
                     if (existingRPr != null)
+                    {
                         newRun.Append((RunProperties)existingRPr.CloneNode(true));
+                    }
                     newRun.Append(new Text(value) { Space = SpaceProcessingModeValues.Preserve });
                     fld.Append(newRun);
                 }
@@ -77,7 +85,10 @@ namespace Mil.Paperwork.Domain.Helpers
                 var runs = para.Elements<Run>().ToList();
                 for (int i = 0; i < runs.Count; i++)
                 {
-                    if (GetFldCharType(runs[i]) != FieldCharValues.Begin) continue;
+                    if (GetFldCharType(runs[i]) != FieldCharValues.Begin)
+                    {
+                        continue;
+                    }
 
                     // Collect instrText between Begin and Separate
                     int sepIdx = -1;
@@ -85,23 +96,43 @@ namespace Mil.Paperwork.Domain.Helpers
                     for (int j = i + 1; j < runs.Count; j++)
                     {
                         var charType = GetFldCharType(runs[j]);
-                        if (charType == FieldCharValues.Separate) { sepIdx = j; break; }
-                        if (charType == FieldCharValues.End) break;
+                        if (charType == FieldCharValues.Separate)
+                        {
+                            sepIdx = j;
+                            break;
+                        }
+                        if (charType == FieldCharValues.End)
+                        {
+                            break;
+                        }
                         instrBuilder.Append(runs[j].GetFirstChild<FieldCode>()?.InnerText ?? string.Empty);
                     }
-                    if (sepIdx == -1) continue;
+                    if (sepIdx == -1)
+                    {
+                        continue;
+                    }
 
                     var instrParts = instrBuilder.ToString()
                         .Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-                    if (!instrParts.Contains("MERGEFIELD") || !instrParts.Contains(cleanName)) continue;
+                    if (!instrParts.Contains("MERGEFIELD") || !instrParts.Contains(cleanName))
+                    {
+                        continue;
+                    }
 
                     // Find End run
                     int endIdx = -1;
                     for (int j = sepIdx + 1; j < runs.Count; j++)
                     {
-                        if (GetFldCharType(runs[j]) == FieldCharValues.End) { endIdx = j; break; }
+                        if (GetFldCharType(runs[j]) == FieldCharValues.End)
+                        {
+                            endIdx = j;
+                            break;
+                        }
                     }
-                    if (endIdx == -1) continue;
+                    if (endIdx == -1)
+                    {
+                        continue;
+                    }
 
                     // Clone formatting from first display run
                     var displayRuns = runs.Skip(sepIdx + 1).Take(endIdx - sepIdx - 1).ToList();
@@ -109,10 +140,15 @@ namespace Mil.Paperwork.Domain.Helpers
 
                     var newRun = new Run();
                     if (existingRPr != null)
+                    {
                         newRun.Append((RunProperties)existingRPr.CloneNode(true));
+                    }
                     newRun.Append(new Text(value) { Space = SpaceProcessingModeValues.Preserve });
 
-                    foreach (var dr in displayRuns) dr.Remove();
+                    foreach (var dr in displayRuns)
+                    {
+                        dr.Remove();
+                    }
                     runs[endIdx].InsertBeforeSelf(newRun);
                     i = endIdx;
                 }
@@ -121,9 +157,14 @@ namespace Mil.Paperwork.Domain.Helpers
 
         public void ReplaceFields(Dictionary<string, string> fieldsMap)
         {
-            if (fieldsMap == null) return;
+            if (fieldsMap == null)
+            {
+                return;
+            }
             foreach (var field in fieldsMap)
+            {
                 ReplaceField(field.Key, field.Value);
+            }
         }
 
         public void ReplaceFieldWithBlock(string fieldName, IList<BlockParagraph> paragraphs)
@@ -136,7 +177,9 @@ namespace Mil.Paperwork.Domain.Helpers
                 .ToList();
 
             if (targets.Count == 0)
+            {
                 return;
+            }
 
             // Replace each occurrence of the placeholder with the block content
             foreach (var target in targets)
@@ -173,7 +216,9 @@ namespace Mil.Paperwork.Domain.Helpers
                         rPr.Append(new FontSize { Val = (bp.FontSize * 2).ToString() });
                         rPr.Append(new FontSizeComplexScript { Val = (bp.FontSize * 2).ToString() });
                         if (bp.IsBold)
+                        {
                             rPr.Append(new Bold());
+                        }
 
                         var run = new Run();
                         run.Append(rPr);
@@ -195,26 +240,36 @@ namespace Mil.Paperwork.Domain.Helpers
                 var instr = fld.Instruction?.Value ?? string.Empty;
                 var parts = instr.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
                 if (parts.Contains("MERGEFIELD") && parts.Contains(fieldName))
+                {
                     return true;
+                }
             }
 
             var runs = para.Elements<Run>().ToList();
             for (int i = 0; i < runs.Count; i++)
             {
-                if (GetFldCharType(runs[i]) != FieldCharValues.Begin) continue;
+                if (GetFldCharType(runs[i]) != FieldCharValues.Begin)
+                {
+                    continue;
+                }
 
                 var instrBuilder = new StringBuilder();
                 for (int j = i + 1; j < runs.Count; j++)
                 {
                     var charType = GetFldCharType(runs[j]);
-                    if (charType == FieldCharValues.Separate || charType == FieldCharValues.End) break;
+                    if (charType == FieldCharValues.Separate || charType == FieldCharValues.End)
+                    {
+                        break;
+                    }
                     instrBuilder.Append(runs[j].GetFirstChild<FieldCode>()?.InnerText ?? string.Empty);
                 }
 
                 var instrParts = instrBuilder.ToString()
                     .Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
                 if (instrParts.Contains("MERGEFIELD") && instrParts.Contains(fieldName))
+                {
                     return true;
+                }
             }
 
             return false;
@@ -226,7 +281,8 @@ namespace Mil.Paperwork.Domain.Helpers
             _wdoc.Dispose();
             _wdoc = null;
             _finalized = true;
-            return _stream.ToArray();
+            var result = _stream.ToArray();
+            return result;
         }
 
         public void Dispose()
@@ -240,7 +296,10 @@ namespace Mil.Paperwork.Domain.Helpers
         }
 
         private static FieldCharValues? GetFldCharType(Run run)
-            => run.GetFirstChild<FieldChar>()?.FieldCharType?.Value;
+        {
+            var result = run.GetFirstChild<FieldChar>()?.FieldCharType?.Value;
+            return result;
+        }
     }
 
     // ---------------------------------------------------------------------------
@@ -256,7 +315,10 @@ namespace Mil.Paperwork.Domain.Helpers
         public WordRow LastRow => new WordRow(_table.Elements<TableRow>().Last(), _table);
 
         public WordRow GetRow(int index)
-            => new WordRow(_table.Elements<TableRow>().ElementAt(index), _table);
+        {
+            var result = new WordRow(_table.Elements<TableRow>().ElementAt(index), _table);
+            return result;
+        }
 
         public WordRow AddRow()
         {
@@ -278,10 +340,14 @@ namespace Mil.Paperwork.Domain.Helpers
             }
 
             _table.Append(newRow);
-            return new WordRow(newRow, _table);
+            var result = new WordRow(newRow, _table);
+            return result;
         }
 
-        public void RemoveRow(WordRow row) => row.Remove();
+        public void RemoveRow(WordRow row)
+        {
+            row.Remove();
+        }
 
         public WordCell MergeCellsVertically(int columnIndex, int startRowIndex, int rowCount)
         {
@@ -291,21 +357,32 @@ namespace Mil.Paperwork.Domain.Helpers
             for (int i = startRowIndex; i < startRowIndex + rowCount && i < rows.Count; i++)
             {
                 var cells = rows[i].Elements<TableCell>().ToList();
-                if (columnIndex >= cells.Count) continue;
+                if (columnIndex >= cells.Count)
+                {
+                    continue;
+                }
                 var cell = cells[columnIndex];
 
                 var tcPr = cell.GetFirstChild<TableCellProperties>();
-                if (tcPr == null) { tcPr = new TableCellProperties(); cell.InsertAt(tcPr, 0); }
+                if (tcPr == null)
+                {
+                    tcPr = new TableCellProperties();
+                    cell.InsertAt(tcPr, 0);
+                }
 
                 tcPr.RemoveAllChildren<VerticalMerge>();
                 tcPr.Append(i == startRowIndex
                     ? new VerticalMerge { Val = MergedCellValues.Restart }
                     : new VerticalMerge());
 
-                if (i == startRowIndex) startCell = cell;
+                if (i == startRowIndex)
+                {
+                    startCell = cell;
+                }
             }
 
-            return new WordCell(startCell!);
+            var result = new WordCell(startCell!);
+            return result;
         }
     }
 
@@ -320,9 +397,16 @@ namespace Mil.Paperwork.Domain.Helpers
 
         internal WordRow(TableRow row, Table table) { _row = row; _table = table; }
 
-        internal void Remove() => _row.Remove();
+        internal void Remove()
+        {
+            _row.Remove();
+        }
 
-        public int GetRowIndex() => _table.Elements<TableRow>().ToList().IndexOf(_row);
+        public int GetRowIndex()
+        {
+            var result = _table.Elements<TableRow>().ToList().IndexOf(_row);
+            return result;
+        }
 
         public int CellCount => _row.Elements<TableCell>()
             .Sum(c => (int)(c.TableCellProperties?.GridSpan?.Val?.Value ?? 1));
@@ -336,24 +420,37 @@ namespace Mil.Paperwork.Domain.Helpers
             {
                 int gridSpan = (int)(cell.TableCellProperties?.GridSpan?.Val?.Value ?? 1);
                 if (currentColumn == logicalColumnIndex)
-                    return new WordCell(cell);
+                {
+                    var wordCell = new WordCell(cell);
+                    return wordCell;
+                }
                 if (logicalColumnIndex < currentColumn + gridSpan)
+                {
                     return WordCell.NoOp;  // inside a merged cell — writes are silently discarded
+                }
                 currentColumn += gridSpan;
             }
 
-            return cells.Count > 0 ? new WordCell(cells.Last()) : WordCell.NoOp;
+            var result = cells.Count > 0 ? new WordCell(cells.Last()) : WordCell.NoOp;
+            return result;
         }
 
         public WordCell CreateMergedCell(int firstColumn, int count)
         {
             var cells = _row.Elements<TableCell>().ToList();
-            if (firstColumn >= cells.Count) return WordCell.NoOp;
+            if (firstColumn >= cells.Count)
+            {
+                return WordCell.NoOp;
+            }
 
             var startCell = cells[firstColumn];
 
             var tcPr = startCell.GetFirstChild<TableCellProperties>();
-            if (tcPr == null) { tcPr = new TableCellProperties(); startCell.InsertAt(tcPr, 0); }
+            if (tcPr == null)
+            {
+                tcPr = new TableCellProperties();
+                startCell.InsertAt(tcPr, 0);
+            }
 
             tcPr.RemoveAllChildren<GridSpan>();
             if (count > 1)
@@ -364,7 +461,8 @@ namespace Mil.Paperwork.Domain.Helpers
             for (int i = firstColumn + 1; i <= lastIdx; i++)
                 cells[i].Remove();
 
-            return new WordCell(startCell);
+            var result = new WordCell(startCell);
+            return result;
         }
     }
 
@@ -386,10 +484,17 @@ namespace Mil.Paperwork.Domain.Helpers
 
         public void AddText(string text, WordCellParameters parameters)
         {
-            if (_isNoOp) return;
+            if (_isNoOp)
+            {
+                return;
+            }
 
             var para = _cell!.GetFirstChild<Paragraph>();
-            if (para == null) { para = new Paragraph(); _cell.Append(para); }
+            if (para == null)
+            {
+                para = new Paragraph();
+                _cell.Append(para);
+            }
 
             // Clear existing runs
             para.Elements<Run>().ToList().ForEach(r => r.Remove());
@@ -401,14 +506,20 @@ namespace Mil.Paperwork.Domain.Helpers
                 pPr.RemoveAllChildren<Justification>();
                 pPr.Append(new Justification { Val = ToJustification(parameters.HorizontalAlignment.Value) });
                 if (para.GetFirstChild<ParagraphProperties>() == null)
+                {
                     para.InsertAt(pPr, 0);
+                }
             }
 
             // Cell vertical alignment
             if (parameters.VerticalAlignment.HasValue)
             {
                 var tcPr = _cell.GetFirstChild<TableCellProperties>();
-                if (tcPr == null) { tcPr = new TableCellProperties(); _cell.InsertAt(tcPr, 0); }
+                if (tcPr == null)
+                {
+                    tcPr = new TableCellProperties();
+                    _cell.InsertAt(tcPr, 0);
+                }
                 tcPr.RemoveAllChildren<TableCellVerticalAlignment>();
                 tcPr.Append(new TableCellVerticalAlignment { Val = ToVerticalAlignment(parameters.VerticalAlignment.Value) });
             }
@@ -418,7 +529,10 @@ namespace Mil.Paperwork.Domain.Helpers
             rPr.Append(new RunFonts { Ascii = FontName, HighAnsi = FontName, ComplexScript = FontName });
             rPr.Append(new FontSize { Val = (parameters.FontSize * 2).ToString() });
             rPr.Append(new FontSizeComplexScript { Val = (parameters.FontSize * 2).ToString() });
-            if (parameters.IsBold) rPr.Append(new Bold());
+            if (parameters.IsBold)
+            {
+                rPr.Append(new Bold());
+            }
 
             var run = new Run();
             run.Append(rPr);
@@ -427,24 +541,36 @@ namespace Mil.Paperwork.Domain.Helpers
         }
 
         public void AddNumber(int value, WordCellParameters parameters)
-            => AddText(value.ToString(), parameters);
+        {
+            AddText(value.ToString(), parameters);
+        }
 
         public void AddPrice(decimal value, WordCellParameters parameters)
-            => AddText(ReportHelper.GetPriceString(value), parameters);
-
-        private static JustificationValues ToJustification(WordHorizontalAlignment alignment) => alignment switch
         {
-            WordHorizontalAlignment.Left => JustificationValues.Left,
-            WordHorizontalAlignment.Right => JustificationValues.Right,
-            _ => JustificationValues.Center
-        };
+            AddText(ReportHelper.GetPriceString(value), parameters);
+        }
 
-        private static TableVerticalAlignmentValues ToVerticalAlignment(WordVerticalAlignment alignment) => alignment switch
+        private static JustificationValues ToJustification(WordHorizontalAlignment alignment)
         {
-            WordVerticalAlignment.Top => TableVerticalAlignmentValues.Top,
-            WordVerticalAlignment.Bottom => TableVerticalAlignmentValues.Bottom,
-            _ => TableVerticalAlignmentValues.Center
-        };
+            var result = alignment switch
+            {
+                WordHorizontalAlignment.Left => JustificationValues.Left,
+                WordHorizontalAlignment.Right => JustificationValues.Right,
+                _ => JustificationValues.Center
+            };
+            return result;
+        }
+
+        private static TableVerticalAlignmentValues ToVerticalAlignment(WordVerticalAlignment alignment)
+        {
+            var result = alignment switch
+            {
+                WordVerticalAlignment.Top => TableVerticalAlignmentValues.Top,
+                WordVerticalAlignment.Bottom => TableVerticalAlignmentValues.Bottom,
+                _ => TableVerticalAlignmentValues.Center
+            };
+            return result;
+        }
     }
 
     // ---------------------------------------------------------------------------

--- a/Mil.Paperwork.Domain/Helpers/WriteOffOrderHelper.cs
+++ b/Mil.Paperwork.Domain/Helpers/WriteOffOrderHelper.cs
@@ -65,7 +65,9 @@ namespace Mil.Paperwork.Domain.Helpers
                     string.Format(ServiceSubtotalFormat, serviceNameGen, ReportHelper.GetPriceString(subtotal)), IndentLevel: 0, FontSize: DocumentFontSize));
 
                 if (i < services.Count - 1)
+                {
                     paragraphs.Add(new BlockParagraph(string.Empty, IndentLevel: 0, FontSize: DocumentFontSize));
+                }
             }
 
             return paragraphs;
@@ -74,7 +76,9 @@ namespace Mil.Paperwork.Domain.Helpers
         internal static string BuildToHeadsOfServices(IList<WriteOffServiceData> services)
         {
             if (services == null || services.Count == 0)
+            {
                 return string.Empty;
+            }
 
             var parts = services.Select(s => string.Format(HeadOfServiceFormat, s.ServiceNameGenitive?.ToLower()));
             var sServices = string.Join(ServicesSeparator, parts);
@@ -96,7 +100,8 @@ namespace Mil.Paperwork.Domain.Helpers
 
         internal static decimal CalculateTotalSum(IList<WriteOffServiceData> services)
         {
-            return Math.Round(services.Sum(s => s.Assets.Sum(a => a.Amount)), SumRoundingPrecision);
+            var result = Math.Round(services.Sum(s => s.Assets.Sum(a => a.Amount)), SumRoundingPrecision);
+            return result;
         }
     }
 }

--- a/Mil.Paperwork.Domain/Reports/WriteOffOrderReport.cs
+++ b/Mil.Paperwork.Domain/Reports/WriteOffOrderReport.cs
@@ -40,7 +40,10 @@ namespace Mil.Paperwork.Domain.Reports
             }
         }
 
-        public byte[] GetReportBytes() => _reportBytes;
+        public byte[] GetReportBytes()
+        {
+            return _reportBytes;
+        }
 
         private void FillSimpleFields(IWriteOffOrderReportData reportData, Dictionary<string, string> reportConfig, WordDocument document)
         {

--- a/Mil.Paperwork.Domain/Services/WriteOffOrderReportService.cs
+++ b/Mil.Paperwork.Domain/Services/WriteOffOrderReportService.cs
@@ -36,7 +36,8 @@ namespace Mil.Paperwork.Domain.Services
             var destinationPath = reportData.GetDestinationPath();
             var rawFileName = string.Format(WriteOffOrderHelper.OUTPUT_NAME_FORMAT, reportData.ReportNum);
             var fileName = PathsHelper.SanitizeFileName(rawFileName);
-            return Path.Combine(destinationPath, fileName);
+            var result = Path.Combine(destinationPath, fileName);
+            return result;
         }
     }
 }

--- a/Mil.Paperwork.Infrastructure/DataModels/Configuration/MilitaryServiceDTO.cs
+++ b/Mil.Paperwork.Infrastructure/DataModels/Configuration/MilitaryServiceDTO.cs
@@ -48,14 +48,16 @@ namespace Mil.Paperwork.Infrastructure.DataModels.Configuration
 
         public List<ReportParameter> GetAllParameters()
         {
-            return [
+            var result = new List<ReportParameter>
+            {
                 ServiceName,
                 ServiceNameFull,
                 ServiceNameGenitive,
                 HeadOfServiceName,
                 HeadOfServicePosition,
                 HeadOfServiceRank
-            ];
+            };
+            return result;
         }
     }
 }

--- a/Mil.Paperwork.Infrastructure/DataModels/ProductDTO.cs
+++ b/Mil.Paperwork.Infrastructure/DataModels/ProductDTO.cs
@@ -44,17 +44,23 @@ namespace Mil.Paperwork.Infrastructure.DataModels
         public bool Equals(ProductDTO x, ProductDTO y)
         {
             if (x == null || y == null)
+            {
                 return false;
+            }
 
-            return x.Name == y.Name;
+            var result = x.Name == y.Name;
+            return result;
         }
 
         public int GetHashCode(ProductDTO obj)
         {
             if (obj == null)
+            {
                 return 0;
+            }
 
-            return HashCode.Combine(obj.Name);
+            var result = HashCode.Combine(obj.Name);
+            return result;
         }
     }
 }

--- a/Mil.Paperwork.Infrastructure/Helpers/EnumHelper.cs
+++ b/Mil.Paperwork.Infrastructure/Helpers/EnumHelper.cs
@@ -28,7 +28,8 @@ namespace Mil.Paperwork.Infrastructure.Helpers
 
         public static IEnumerable<T> GetValues<T>() where T : Enum
         {
-            return Enum.GetValues(typeof(T)).Cast<T>();
+            var result = Enum.GetValues(typeof(T)).Cast<T>();
+            return result;
         }
 
         /// <summary>
@@ -36,8 +37,9 @@ namespace Mil.Paperwork.Infrastructure.Helpers
         /// </summary>
         public static IEnumerable<(T Value, string Description)> GetValuesWithDescriptions<T>() where T : Enum
         {
-            return Enum.GetValues(typeof(T)).Cast<T>()
-                       .Select(v => (v, GetDescription(v)));
+            var result = Enum.GetValues(typeof(T)).Cast<T>()
+                             .Select(v => (v, GetDescription(v)));
+            return result;
         }
 
         /// <summary>
@@ -45,7 +47,8 @@ namespace Mil.Paperwork.Infrastructure.Helpers
         /// </summary>
         public static Dictionary<T, string> GetDescriptionDictionary<T>() where T : Enum
         {
-            return GetValuesWithDescriptions<T>().ToDictionary(t => t.Value, t => t.Description);
+            var result = GetValuesWithDescriptions<T>().ToDictionary(t => t.Value, t => t.Description);
+            return result;
         }
     }
 }

--- a/Mil.Paperwork.Infrastructure/Helpers/JsonHelper.cs
+++ b/Mil.Paperwork.Infrastructure/Helpers/JsonHelper.cs
@@ -13,7 +13,8 @@ namespace Mil.Paperwork.Infrastructure.Helpers
         public static string WriteJson<T>(T obj)
         {
             var options = new JsonSerializerOptions { WriteIndented = true };
-            return JsonSerializer.Serialize(obj, options);
+            var result = JsonSerializer.Serialize(obj, options);
+            return result;
         }
     }
 }

--- a/Mil.Paperwork.Infrastructure/Services/DataService.cs
+++ b/Mil.Paperwork.Infrastructure/Services/DataService.cs
@@ -47,7 +47,9 @@ namespace Mil.Paperwork.Infrastructure.Services
         public void SaveProductsData(IList<ProductDTO> products)
         {
             if (products == null)
+            {
                 return;
+            }
 
             // Sort the list alphabetically by name
             var sortedProducts = products?.OrderBy(p => p.Name).ToList();
@@ -59,7 +61,9 @@ namespace Mil.Paperwork.Infrastructure.Services
         public void RemoveProductsData(IList<ProductDTO> productsToRemove)
         {
             if (productsToRemove == null || productsToRemove.Count == 0)
+            {
                 return;
+            }
 
             var namesToRemove = new HashSet<string>(productsToRemove.Select(p => p.AlmostUniqueID));
             _storageData.ProductsData?.RemoveAll(p => namesToRemove.Contains(p.AlmostUniqueID));
@@ -146,7 +150,9 @@ namespace Mil.Paperwork.Infrastructure.Services
         public void SaveMeasurementUnitsData(IList<MeasurementUnitDTO> units)
         {
             if (units == null)
+            {
                 return;
+            }
 
             // Sort the list alphabetically by name
             var sortedUnits = units?.OrderBy(p => p.Name).ToList();
@@ -186,7 +192,9 @@ namespace Mil.Paperwork.Infrastructure.Services
         public void SavePeopleData(IList<PersonDTO> people)
         {
             if (people == null)
+            {
                 return;
+            }
 
             // Sort the list alphabetically by name
             var sortedPeople = people?.OrderBy(p => p.FullName).ToList();
@@ -204,7 +212,9 @@ namespace Mil.Paperwork.Infrastructure.Services
         public void SaveServicesData(IList<MilServiceEntry> services)
         {
             if (services == null)
+            {
                 return;
+            }
 
             var sorted = services.OrderBy(s => s.NominativeName).ToList();
             _storageData.Services = sorted;

--- a/Mil.Paperwork.Infrastructure/Services/FileStorageService.cs
+++ b/Mil.Paperwork.Infrastructure/Services/FileStorageService.cs
@@ -35,7 +35,8 @@ namespace Mil.Paperwork.Infrastructure.Services
             }
 
             var jsonContent = File.ReadAllText(filePath);
-            return JsonHelper.ReadJson<T>(jsonContent);
+            var result = JsonHelper.ReadJson<T>(jsonContent);
+            return result;
         }
 
         public void WriteJsonToFile<T>(T obj, string fileName, string directory = null)

--- a/Mil.Paperwork.Infrastructure/Services/ReportDataService.cs
+++ b/Mil.Paperwork.Infrastructure/Services/ReportDataService.cs
@@ -158,7 +158,8 @@ namespace Mil.Paperwork.Infrastructure.Services
                 _ => []
             };
 
-            return [.. result];
+            List<ReportParameter> resultList = [.. result];
+            return resultList;
         }
 
         public Dictionary<string, string> GetReportParametersDictionary(ReportType reportType)
@@ -216,7 +217,8 @@ namespace Mil.Paperwork.Infrastructure.Services
 
             var result = dataExists ? militaryServiceDTO.GetAllParameters() ?? [] : [];
 
-            return [.. result];
+            List<ReportParameter> resultList = [.. result];
+            return resultList;
         }
 
         public CommissionDTO GetCommissionData(CommissionType commissionType, bool withReload = false)

--- a/Mil.Paperwork.Tests/ConfigurationDataFilesTests.cs
+++ b/Mil.Paperwork.Tests/ConfigurationDataFilesTests.cs
@@ -13,7 +13,9 @@ namespace Mil.Paperwork.Tests
             {
                 var sln = Path.Combine(dir.FullName, "Mil.Paperwork.WriteOff.sln");
                 if (File.Exists(sln))
+                {
                     return dir.FullName;
+                }
 
                 dir = dir.Parent;
             }
@@ -24,7 +26,8 @@ namespace Mil.Paperwork.Tests
         private static string ResolveDataFilePath(string relativePathFromRepoRoot)
         {
             var repoRoot = FindRepoRoot();
-            return Path.GetFullPath(Path.Combine(repoRoot, relativePathFromRepoRoot.Replace('/', Path.DirectorySeparatorChar)));
+            var result = Path.GetFullPath(Path.Combine(repoRoot, relativePathFromRepoRoot.Replace('/', Path.DirectorySeparatorChar)));
+            return result;
         }
 
         [Fact]

--- a/Mil.Paperwork.Tests/WriteOffOrderReportTests.cs
+++ b/Mil.Paperwork.Tests/WriteOffOrderReportTests.cs
@@ -15,17 +15,68 @@ namespace Mil.Paperwork.Tests
     {
         private sealed class StubReportDataService : IReportDataService
         {
-            public Dictionary<string, string> GetReportParametersDictionary(ReportType _) => [];
-            public List<ReportParameter> GetReportParameters(ReportType _, bool __ = false) => [];
-            public Dictionary<string, string> GetServiceReportParametersDictionary(string? _ = null) => [];
-            public List<ReportParameter> GetServiceReportParameters(string? _ = null, bool __ = false) => [];
-            public Dictionary<string, MilitaryServiceDTO> GetAllServices(bool _ = false) => [];
-            public string GetSelectedService(bool _ = false) => string.Empty;
-            public CommissionDTO GetCommissionData(CommissionType _, bool __ = false) => new();
-            public AssetType GetAssetType() => AssetType.Default;
-            public ICommisionsConfigSection GetCommissionsConfig() => null!;
-            public CommissionDTO GetCommission(ReportType _) => new();
-            public bool ImportReportConfig(ReportDataConfigDTO _) => true;
+            public Dictionary<string, string> GetReportParametersDictionary(ReportType _)
+            {
+                Dictionary<string, string> result = [];
+                return result;
+            }
+
+            public List<ReportParameter> GetReportParameters(ReportType _, bool __ = false)
+            {
+                List<ReportParameter> result = [];
+                return result;
+            }
+
+            public Dictionary<string, string> GetServiceReportParametersDictionary(string? _ = null)
+            {
+                Dictionary<string, string> result = [];
+                return result;
+            }
+
+            public List<ReportParameter> GetServiceReportParameters(string? _ = null, bool __ = false)
+            {
+                List<ReportParameter> result = [];
+                return result;
+            }
+
+            public Dictionary<string, MilitaryServiceDTO> GetAllServices(bool _ = false)
+            {
+                Dictionary<string, MilitaryServiceDTO> result = [];
+                return result;
+            }
+
+            public string GetSelectedService(bool _ = false)
+            {
+                return string.Empty;
+            }
+
+            public CommissionDTO GetCommissionData(CommissionType _, bool __ = false)
+            {
+                var result = new CommissionDTO();
+                return result;
+            }
+
+            public AssetType GetAssetType()
+            {
+                return AssetType.Default;
+            }
+
+            public ICommisionsConfigSection GetCommissionsConfig()
+            {
+                return null!;
+            }
+
+            public CommissionDTO GetCommission(ReportType _)
+            {
+                var result = new CommissionDTO();
+                return result;
+            }
+
+            public bool ImportReportConfig(ReportDataConfigDTO _)
+            {
+                return true;
+            }
+
             public void SaveReportConfigExternally(string _) { }
             public void SaveReportConfig(IReadOnlyCollection<ReportParameter> _, ReportType __) { }
             public void SaveReportConfigTemprorary(IReadOnlyCollection<ReportParameter> _, ReportType __) { }
@@ -39,8 +90,17 @@ namespace Mil.Paperwork.Tests
         private sealed class CapturingFileStorageService : IFileStorageService
         {
             public byte[]? SavedBytes { get; private set; }
-            public void SaveFile(string _, byte[] bytes) => SavedBytes = bytes;
-            public T? ReadJsonFile<T>(string _, string? __ = null) => default;
+
+            public void SaveFile(string _, byte[] bytes)
+            {
+                SavedBytes = bytes;
+            }
+
+            public T? ReadJsonFile<T>(string _, string? __ = null)
+            {
+                return default;
+            }
+
             public void WriteJsonToFile<T>(T _, string __, string? ___ = null) { }
             public void WriteJsonToFile<T>(T _, string __) { }
         }
@@ -51,54 +111,59 @@ namespace Mil.Paperwork.Tests
             new() { Rank = "старший солдат",   Name = "КОВАЛЬОВ Дмитро Миколайович",  Position = "майстер – номер обслуги мінометного взводу" }
         ];
 
-        private static WriteOffOrderReportData BuildTestData() => new()
+        private static WriteOffOrderReportData BuildTestData()
         {
-            ReportNum = "42",
-            ReportDate = new DateTime(2026, 5, 30),
-            EventDate = new DateTime(2026, 5, 28),
-            EventTime = "14:35",
-            BattleOrder = "7",
-            BattleOrderDate = new DateTime(2026, 5, 20),
-            BattleOrderLocation = "н.п. Тест",
-            SubdivisionName = "1 механізований батальйон",
-            ReporterRank = "солдата",
-            ReporterName = "Тестового Тест Тестовича",
-            CreatorPosition = "Начальник служби",
-            CreatorRank = "майор",
-            CreatorName = "Іванов І.І.",
-            MilUnitApproval = "в/ч А1234",
-            WhatHappened = "Внаслідок бойового зіткнення майно прийшло до непридатності.",
-            Services =
-            [
-                new WriteOffServiceData
-                {
-                    ServiceName = "Інженерна служба",
-                    ServiceNameGenitive = "інженерної служби",
-                    Assets =
-                    [
-                        new() { Name = "Лопата саперна", Count = 3, MeasurementUnit = "шт", Amount = 450.00m },
-                        new() { Name = "Мотузка страховна", Count = 1, MeasurementUnit = "шт", Amount = 1200.50m }
-                    ]
-                },
-                new WriteOffServiceData
-                {
-                    ServiceName = "Служба зв'язку",
-                    ServiceNameGenitive = "служби зв'язку",
-                    Assets =
-                    [
-                        new() { Name = "Радіостанція Р-187П1", Count = 1, MeasurementUnit = "шт", Amount = 35000.00m }
-                    ]
-                }
-            ],
-            DestinationFolder = Path.GetTempPath()
-        };
+            var result = new WriteOffOrderReportData
+            {
+                ReportNum = "42",
+                ReportDate = new DateTime(2026, 5, 30),
+                EventDate = new DateTime(2026, 5, 28),
+                EventTime = "14:35",
+                BattleOrder = "7",
+                BattleOrderDate = new DateTime(2026, 5, 20),
+                BattleOrderLocation = "н.п. Тест",
+                SubdivisionName = "1 механізований батальйон",
+                ReporterRank = "солдата",
+                ReporterName = "Тестового Тест Тестовича",
+                CreatorPosition = "Начальник служби",
+                CreatorRank = "майор",
+                CreatorName = "Іванов І.І.",
+                MilUnitApproval = "в/ч А1234",
+                WhatHappened = "Внаслідок бойового зіткнення майно прийшло до непридатності.",
+                Services =
+                [
+                    new WriteOffServiceData
+                    {
+                        ServiceName = "Інженерна служба",
+                        ServiceNameGenitive = "інженерної служби",
+                        Assets =
+                        [
+                            new() { Name = "Лопата саперна", Count = 3, MeasurementUnit = "шт", Amount = 450.00m },
+                            new() { Name = "Мотузка страховна", Count = 1, MeasurementUnit = "шт", Amount = 1200.50m }
+                        ]
+                    },
+                    new WriteOffServiceData
+                    {
+                        ServiceName = "Служба зв'язку",
+                        ServiceNameGenitive = "служби зв'язку",
+                        Assets =
+                        [
+                            new() { Name = "Радіостанція Р-187П1", Count = 1, MeasurementUnit = "шт", Amount = 35000.00m }
+                        ]
+                    }
+                ],
+                DestinationFolder = Path.GetTempPath()
+            };
+            return result;
+        }
 
         private static string GetDocumentXml(byte[] docxBytes)
         {
             using var zip = new ZipArchive(new MemoryStream(docxBytes), ZipArchiveMode.Read);
             var entry = zip.GetEntry("word/document.xml")!;
             using var reader = new StreamReader(entry.Open(), Encoding.UTF8);
-            return reader.ReadToEnd();
+            var result = reader.ReadToEnd();
+            return result;
         }
 
         [Fact]

--- a/Mil.Paperwork.UI/App.axaml
+++ b/Mil.Paperwork.UI/App.axaml
@@ -10,8 +10,13 @@
 	</Application.DataTemplates>
 
 	<Application.Resources>
-		<x:Double x:Key="DataGridSortIconMinWidth">0</x:Double>
-		<converters:EnumDescriptionConverter x:Key="EnumDescriptionConverter" />
+		<ResourceDictionary>
+			<ResourceDictionary.MergedDictionaries>
+				<ResourceInclude Source="Assets/Icons.axaml"/>
+			</ResourceDictionary.MergedDictionaries>
+			<x:Double x:Key="DataGridSortIconMinWidth">0</x:Double>
+			<converters:EnumDescriptionConverter x:Key="EnumDescriptionConverter" />
+		</ResourceDictionary>
 	</Application.Resources>
 
 	<Application.Styles>

--- a/Mil.Paperwork.UI/Assets/Icons.axaml
+++ b/Mil.Paperwork.UI/Assets/Icons.axaml
@@ -1,0 +1,18 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Table grid outline + down arrow: used for "add row" buttons -->
+    <StreamGeometry x:Key="IconAddTableRow">
+        M0,0 H24 V2 H0 Z M0,7 H24 V9 H0 Z M0,13 H24 V15 H0 Z
+        M0,0 H2 V15 H0 Z M22,0 H24 V15 H22 Z M11,0 H13 V15 H11 Z
+        M11,15 H13 V19 H11 Z M7,19 L12,23 L17,19 Z
+    </StreamGeometry>
+
+    <!-- Table grid outline + × below: used for "remove row" buttons -->
+    <StreamGeometry x:Key="IconRemoveTableRow">
+        M0,0 H24 V2 H0 Z M0,7 H24 V9 H0 Z M0,13 H24 V15 H0 Z
+        M0,0 H2 V15 H0 Z M22,0 H24 V15 H22 Z M11,0 H13 V15 H11 Z
+        M15,16 L17,16 L9,24 L7,24 Z M7,16 L9,16 L17,24 L15,24 Z
+    </StreamGeometry>
+
+</ResourceDictionary>

--- a/Mil.Paperwork.UI/Converters/BoolToFontWeightConverter.cs
+++ b/Mil.Paperwork.UI/Converters/BoolToFontWeightConverter.cs
@@ -11,11 +11,15 @@ namespace Mil.Paperwork.UI.Converters
         public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
             if (value is bool b && b)
+            {
                 return FontWeight.Bold;
+            }
             return FontWeight.Normal;
         }
 
         public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-            => BindingOperations.DoNothing;
+        {
+            return BindingOperations.DoNothing;
+        }
     }
 }

--- a/Mil.Paperwork.UI/Converters/EnumDescriptionConverter.cs
+++ b/Mil.Paperwork.UI/Converters/EnumDescriptionConverter.cs
@@ -13,10 +13,14 @@ namespace Mil.Paperwork.UI.Converters
             {
                 var fi = enumValue.GetType().GetField(enumValue.ToString());
                 var attributes = (DescriptionAttribute[])fi.GetCustomAttributes(typeof(DescriptionAttribute), false);
-                return attributes.Length > 0 ? attributes[0].Description : enumValue.ToString();
+                var result = attributes.Length > 0 ? attributes[0].Description : enumValue.ToString();
+                return result;
             }
             return value;
         }
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Mil.Paperwork.UI/Converters/EnumToBoolConverter.cs
+++ b/Mil.Paperwork.UI/Converters/EnumToBoolConverter.cs
@@ -9,12 +9,14 @@ namespace Mil.Paperwork.UI.Converters
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return value?.Equals(parameter);
+            var result = value?.Equals(parameter);
+            return result;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return value.Equals(true) ? parameter : BindingOperations.DoNothing;
+            var result = value.Equals(true) ? parameter : BindingOperations.DoNothing;
+            return result;
         }
     }
 }

--- a/Mil.Paperwork.UI/Converters/InversedBoolConverter.cs
+++ b/Mil.Paperwork.UI/Converters/InversedBoolConverter.cs
@@ -10,7 +10,9 @@ namespace Mil.Paperwork.UI.Converters
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (!(value is bool boolValue))
+            {
                 return BindingOperations.DoNothing;
+            }
 
             return !boolValue;
         }
@@ -18,7 +20,9 @@ namespace Mil.Paperwork.UI.Converters
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (!(value is bool boolValue))
+            {
                 return BindingOperations.DoNothing;
+            }
 
             return !boolValue;
         }

--- a/Mil.Paperwork.UI/Program.cs
+++ b/Mil.Paperwork.UI/Program.cs
@@ -9,14 +9,19 @@ namespace Mil.Paperwork.UI
         // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
         // yet and stuff might break.
         [STAThread]
-        public static void Main(string[] args) => BuildAvaloniaApp()
-            .StartWithClassicDesktopLifetime(args);
+        public static void Main(string[] args)
+        {
+            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+        }
 
         // Avalonia configuration, don't remove; also used by visual designer.
         public static AppBuilder BuildAvaloniaApp()
-            => AppBuilder.Configure<App>()
+        {
+            var result = AppBuilder.Configure<App>()
                 .UsePlatformDetect()
                 .WithInterFont()
                 .LogToTrace();
+            return result;
+        }
     }
 }

--- a/Mil.Paperwork.UI/Services/AvaloniaDialogService.cs
+++ b/Mil.Paperwork.UI/Services/AvaloniaDialogService.cs
@@ -42,7 +42,8 @@ namespace Mil.Paperwork.UI.Services
         public DialogResult ShowMessage(string message, string caption = "", DialogButtons buttons = DialogButtons.OK, DialogIcon icon = DialogIcon.Information)
         {
             // Call async variant but avoid deadlock by ensuring async internals do not capture SynchronizationContext.
-            return ShowMessageAsync(message, caption, buttons, icon).GetAwaiter().GetResult();
+            var result = ShowMessageAsync(message, caption, buttons, icon).GetAwaiter().GetResult();
+            return result;
         }
 
         public async Task<DialogResult> ShowMessageAsync(string message, string caption = "", DialogButtons buttons = DialogButtons.OK, DialogIcon icon = DialogIcon.Information)
@@ -134,7 +135,7 @@ namespace Mil.Paperwork.UI.Services
                 var firstItem = itemsList[0];
                 var localPath = firstItem.TryGetLocalPath();
 
-                path = !string.IsNullOrEmpty(localPath) ? localPath : firstItem.Name;
+                path = string.IsNullOrEmpty(localPath) ? firstItem.Name : localPath;
             }
 
             return result;
@@ -143,11 +144,15 @@ namespace Mil.Paperwork.UI.Services
         private List<FilePickerFileType>? GetFilesFilter(string filter)
         {
             if (string.IsNullOrWhiteSpace(filter))
+            {
                 return null;
+            }
 
             var parts = filter.Split('|');
             if (parts.Length < 2)
+            {
                 return null;
+            }
 
             var result = new List<FilePickerFileType>();
 

--- a/Mil.Paperwork.UI/ViewLocator.cs
+++ b/Mil.Paperwork.UI/ViewLocator.cs
@@ -12,17 +12,21 @@ namespace Mil.Paperwork.UI
         public Control? Build(object? param)
         {
             if (param is null)
+            {
                 return null;
+            }
 
             var name = param.GetType().FullName!.Replace("ViewModel", "View", StringComparison.Ordinal);
             var type = Type.GetType(name);
 
             if (type != null)
             {
-                return (Control)Activator.CreateInstance(type)!;
+                var control = (Control)Activator.CreateInstance(type)!;
+                return control;
             }
 
-            return new TextBlock { Text = "Not Found: " + name };
+            var result = new TextBlock { Text = "Not Found: " + name };
+            return result;
         }
 
         public bool Match(object? data)

--- a/Mil.Paperwork.UI/ViewModels/Controls/AssetAccetpanceViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Controls/AssetAccetpanceViewModel.cs
@@ -89,12 +89,14 @@ namespace Mil.Paperwork.UI.ViewModels
 
         public PersonDTO GetAcceptedDTO()
         {
-            return new PersonDTO(_personAcceptedName, _personAcceptedPosition, _personAcceptedRank);
+            var result = new PersonDTO(_personAcceptedName, _personAcceptedPosition, _personAcceptedRank);
+            return result;
         }
 
         public PersonDTO GetHandedDTO()
         {
-            return new PersonDTO(_personHandedName, _personHandedPosition, _personHandedRank);
+            var result = new PersonDTO(_personHandedName, _personHandedPosition, _personHandedRank);
+            return result;
         }
 
         public bool GetIsReceiverValid()

--- a/Mil.Paperwork.UI/ViewModels/Controls/MessageBoxViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Controls/MessageBoxViewModel.cs
@@ -53,13 +53,17 @@ namespace Mil.Paperwork.UI.ViewModels.Controls
             RequestClose?.Invoke(r);
         }
 
-        private string GetIconGlyph(DialogIcon icon) => icon switch
+        private string GetIconGlyph(DialogIcon icon)
         {
-            DialogIcon.Information => "i",
-            DialogIcon.Warning => "!",
-            DialogIcon.Error => "×",
-            DialogIcon.Question => "?",
-            _ => string.Empty
-        };
+            var result = icon switch
+            {
+                DialogIcon.Information => "i",
+                DialogIcon.Warning => "!",
+                DialogIcon.Error => "×",
+                DialogIcon.Question => "?",
+                _ => string.Empty
+            };
+            return result;
+        }
     }
 }

--- a/Mil.Paperwork.UI/ViewModels/Controls/ProductSelectionViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Controls/ProductSelectionViewModel.cs
@@ -61,7 +61,8 @@ namespace Mil.Paperwork.UI.ViewModels.Controls
 
         private IList<ProductDTO> LoadProductData()
         {
-            return _dataService.LoadProductsData();
+            var result = _dataService.LoadProductsData();
+            return result;
         }
     }
 }

--- a/Mil.Paperwork.UI/ViewModels/Dictionaries/MeasurementUnitViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Dictionaries/MeasurementUnitViewModel.cs
@@ -37,11 +37,15 @@ namespace Mil.Paperwork.UI.ViewModels.Dictionaries
             Gender = dto.Gender;
         }
 
-        public MeasurementUnitDTO ToDTO() => new()
+        public MeasurementUnitDTO ToDTO()
         {
-            Name = Name,
-            ShortName = ShortName,
-            Gender = Gender
-        };
+            var result = new MeasurementUnitDTO
+            {
+                Name = Name,
+                ShortName = ShortName,
+                Gender = Gender
+            };
+            return result;
+        }
     }
 }

--- a/Mil.Paperwork.UI/ViewModels/Dictionaries/MeasurementUnitsDictionaryViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Dictionaries/MeasurementUnitsDictionaryViewModel.cs
@@ -45,10 +45,14 @@ namespace Mil.Paperwork.UI.ViewModels.Dictionaries
         {
             var units = _dataService.LoadMeasurementUnitsData();
             var unitViewModels = units.Select(x => new MeasurementUnitViewModel(x));
-            return unitViewModels.ToArray();
+            var result = unitViewModels.ToArray();
+            return result;
         }
 
-        private void AddItemCommandExecute() => Units.Add(new MeasurementUnitViewModel());
+        private void AddItemCommandExecute()
+        {
+            Units.Add(new MeasurementUnitViewModel());
+        }
 
         private void RemoveItemCommandExecute(MeasurementUnitViewModel unit)
         {

--- a/Mil.Paperwork.UI/ViewModels/Dictionaries/MilServiceEntryViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Dictionaries/MilServiceEntryViewModel.cs
@@ -37,11 +37,15 @@ namespace Mil.Paperwork.UI.ViewModels.Dictionaries
             _genitiveName = dto.GenitiveName;
         }
 
-        public MilServiceEntry ToDTO() => new()
+        public MilServiceEntry ToDTO()
         {
-            Id = Id,
-            NominativeName = NominativeName,
-            GenitiveName = GenitiveName
-        };
+            var result = new MilServiceEntry
+            {
+                Id = Id,
+                NominativeName = NominativeName,
+                GenitiveName = GenitiveName
+            };
+            return result;
+        }
     }
 }

--- a/Mil.Paperwork.UI/ViewModels/Dictionaries/PeopleDictionaryViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Dictionaries/PeopleDictionaryViewModel.cs
@@ -48,7 +48,8 @@ namespace Mil.Paperwork.UI.ViewModels.Dictionaries
         {
             var people = _dataService.LoadPeopleData();
             var productViewModels = people.Select(x => new PersonViewModel(x));
-            return productViewModels.ToArray();
+            var result = productViewModels.ToArray();
+            return result;
         }
 
         private void AddItemCommandExecute()

--- a/Mil.Paperwork.UI/ViewModels/Dictionaries/PersonViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Dictionaries/PersonViewModel.cs
@@ -54,13 +54,17 @@ namespace Mil.Paperwork.UI.ViewModels.Dictionaries
             Rank = dto.Rank;
         }
 
-        public PersonDTO ToDTO() => new()
+        public PersonDTO ToDTO()
         {
-            FirstName = FirstName,
-            LastName = LastName,
-            Patronymic = Patronymic,
-            Position = Position,
-            Rank = Rank
-        };
+            var result = new PersonDTO
+            {
+                FirstName = FirstName,
+                LastName = LastName,
+                Patronymic = Patronymic,
+                Position = Position,
+                Rank = Rank
+            };
+            return result;
+        }
     }
 }

--- a/Mil.Paperwork.UI/ViewModels/Dictionaries/ProductViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Dictionaries/ProductViewModel.cs
@@ -79,7 +79,7 @@ namespace Mil.Paperwork.UI.ViewModels.Dictionaries
 
         public ProductDTO ToProductDTO()
         {
-            return new ProductDTO
+            var result = new ProductDTO
             {
                 Name = Name,
                 ShortName = ShortName,
@@ -90,6 +90,7 @@ namespace Mil.Paperwork.UI.ViewModels.Dictionaries
                 WarrantyPeriodMonths = WarrantyPeriodMonths,
                 ResourceYears = ResourceYears
             };
+            return result;
         }
     }
 }

--- a/Mil.Paperwork.UI/ViewModels/Dictionaries/ProductsDictionaryViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Dictionaries/ProductsDictionaryViewModel.cs
@@ -60,7 +60,8 @@ namespace Mil.Paperwork.UI.ViewModels.Dictionaries
         {
             var products = _dataService.LoadProductsData();
             var productViewModels = products.Select(x => new ProductViewModel(x));
-            return productViewModels.ToArray();
+            var result = productViewModels.ToArray();
+            return result;
         }
 
         private void ReloadProductsData()

--- a/Mil.Paperwork.UI/ViewModels/Dictionaries/ServicesDictionaryViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Dictionaries/ServicesDictionaryViewModel.cs
@@ -31,9 +31,10 @@ namespace Mil.Paperwork.UI.ViewModels.Dictionaries
 
         private MilServiceEntryViewModel[] GetServicesData()
         {
-            return _dataService.LoadServicesData()
+            var result = _dataService.LoadServicesData()
                 .Select(s => new MilServiceEntryViewModel(s))
                 .ToArray();
+            return result;
         }
 
         private void AddItemCommandExecute()
@@ -44,7 +45,9 @@ namespace Mil.Paperwork.UI.ViewModels.Dictionaries
         private void RemoveItemCommandExecute(MilServiceEntryViewModel service)
         {
             if (service != null && Services.Contains(service))
+            {
                 Services.Remove(service);
+            }
         }
 
         private void SaveCommandExecute()
@@ -58,7 +61,9 @@ namespace Mil.Paperwork.UI.ViewModels.Dictionaries
             var services = GetServicesData();
             Services.Clear();
             foreach (var s in services)
+            {
                 Services.Add(s);
+            }
         }
     }
 }

--- a/Mil.Paperwork.UI/ViewModels/Reports/AssetDismantlingViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Reports/AssetDismantlingViewModel.cs
@@ -115,7 +115,10 @@ namespace Mil.Paperwork.UI.ViewModels.Reports
 
         public override void RestoreState()
         {
-            if (_memento == null) return;
+            if (_memento == null)
+            {
+                return;
+            }
 
             IsValid = _memento.IsValid;
             Name = _memento.Name;

--- a/Mil.Paperwork.UI/ViewModels/Reports/AssetValuationViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Reports/AssetValuationViewModel.cs
@@ -413,7 +413,10 @@ namespace Mil.Paperwork.UI.ViewModels.Reports
 
         public virtual void RestoreState()
         {
-            if (_memento == null) return;
+            if (_memento == null)
+            {
+                return;
+            }
 
             IsValid = _memento.IsValid;
             Name = _memento.Name;

--- a/Mil.Paperwork.UI/ViewModels/Reports/CommissioningActReportViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Reports/CommissioningActReportViewModel.cs
@@ -422,7 +422,8 @@ namespace Mil.Paperwork.UI.ViewModels.Reports
 
         private bool RemoveRowCanExecute()
         {
-            return SelectedIdentifier != null;
+            var result = SelectedIdentifier != null;
+            return result;
         }
 
 

--- a/Mil.Paperwork.UI/ViewModels/Reports/WriteOffOrderViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Reports/WriteOffOrderViewModel.cs
@@ -182,14 +182,20 @@ namespace Mil.Paperwork.UI.ViewModels.Reports
         private void RemoveSelectedWitness()
         {
             if (SelectedWitness != null)
+            {
                 Witnesses.Remove(SelectedWitness);
+            }
         }
 
         private static bool IsValidEventTime(string value)
         {
-            if (value is null || value.Length != 5 || value[2] != ':') return false;
-            return int.TryParse(value[..2], out int h) && int.TryParse(value[3..], out int m)
+            if (value is null || value.Length != 5 || value[2] != ':')
+            {
+                return false;
+            }
+            var result = int.TryParse(value[..2], out int h) && int.TryParse(value[3..], out int m)
                 && h is >= 0 and <= 23 && m is >= 0 and <= 59;
+            return result;
         }
 
         private async void GenerateReportCommandExecute()

--- a/Mil.Paperwork.UI/ViewModels/Reports/WriteOffServiceViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Reports/WriteOffServiceViewModel.cs
@@ -140,17 +140,21 @@ namespace Mil.Paperwork.UI.ViewModels.Reports
             }
         }
 
-        public WriteOffServiceData ToServiceData() => new WriteOffServiceData
+        public WriteOffServiceData ToServiceData()
         {
-            ServiceName = SelectedService?.NominativeName ?? string.Empty,
-            ServiceNameGenitive = SelectedService?.GenitiveName ?? string.Empty,
-            Assets = [.. Assets.Select(a => new WriteOffServiceAssetData
+            var result = new WriteOffServiceData
             {
-                Name = a.Name,
-                Count = a.Count,
-                MeasurementUnit = a.MeasurementUnit,
-                Amount = a.Amount
-            })]
-        };
+                ServiceName = SelectedService?.NominativeName ?? string.Empty,
+                ServiceNameGenitive = SelectedService?.GenitiveName ?? string.Empty,
+                Assets = [.. Assets.Select(a => new WriteOffServiceAssetData
+                {
+                    Name = a.Name,
+                    Count = a.Count,
+                    MeasurementUnit = a.MeasurementUnit,
+                    Amount = a.Amount
+                })]
+            };
+            return result;
+        }
     }
 }

--- a/Mil.Paperwork.UI/ViewModels/Reports/WriteOffWitnessViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Reports/WriteOffWitnessViewModel.cs
@@ -13,11 +13,15 @@ namespace Mil.Paperwork.UI.ViewModels.Reports
         public string Name { get => _name; set => SetProperty(ref _name, value); }
         public string Position { get => _position; set => SetProperty(ref _position, value); }
 
-        public WriteOffWitnessData ToWitnessData() => new()
+        public WriteOffWitnessData ToWitnessData()
         {
-            Rank = Rank,
-            Name = Name,
-            Position = Position
-        };
+            var result = new WriteOffWitnessData
+            {
+                Rank = Rank,
+                Name = Name,
+                Position = Position
+            };
+            return result;
+        }
     }
 }

--- a/Mil.Paperwork.UI/ViewModels/Tabs/CommissionsConfigViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Tabs/CommissionsConfigViewModel.cs
@@ -120,12 +120,13 @@ namespace Mil.Paperwork.UI.ViewModels.Tabs
 
         private CommissionDTO GetCurrentCommissionDTO()
         {
-            return new CommissionDTO()
+            var result = new CommissionDTO()
             {
                 Name = CommissionName,
                 Description = CommissionDescription,
                 Squad = [.. CurrentCommission]
             };
+            return result;
         }
 
         private async void RefreshCommandExecute()

--- a/Mil.Paperwork.UI/ViewModels/Tabs/MilitaryServiceViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Tabs/MilitaryServiceViewModel.cs
@@ -126,7 +126,7 @@ namespace Mil.Paperwork.UI.ViewModels.Tabs
 
         public MilitaryServiceDTO GetDTO()
         {
-            return new MilitaryServiceDTO()
+            var result = new MilitaryServiceDTO()
             {
                 ServiceName = _serviceName,
                 ServiceNameFull = _serviceNameFull,
@@ -138,6 +138,7 @@ namespace Mil.Paperwork.UI.ViewModels.Tabs
                 AssetTypes = [AssetType.ToString()]
                 //AssetTypes = AssetTypes.Select(x => x.ToString()).ToList()
             };
+            return result;
         }
     }
 }

--- a/Mil.Paperwork.UI/ViewModels/Tabs/ServicesConfigViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Tabs/ServicesConfigViewModel.cs
@@ -104,7 +104,10 @@ namespace Mil.Paperwork.UI.ViewModels.Tabs
 
         private void UpdateServicesDefaultFlags()
         {
-            if (Services == null) return;
+            if (Services == null)
+            {
+                return;
+            }
             foreach (var s in Services)
             {
                 s.SetAsDefault(s.ServiceKey == _defaultServiceKey);

--- a/Mil.Paperwork.UI/Windows/ImportDialogWindow.axaml.cs
+++ b/Mil.Paperwork.UI/Windows/ImportDialogWindow.axaml.cs
@@ -95,14 +95,23 @@ public partial class ImportDialogWindow : Window
 
     private void RebuildColumns()
     {
-        if (PreviewDataGrid == null) return;
+        if (PreviewDataGrid == null)
+        {
+            return;
+        }
 
         PreviewDataGrid.Columns.Clear();
 
-        if (_viewModel?.PreviewTable == null) return;
+        if (_viewModel?.PreviewTable == null)
+        {
+            return;
+        }
 
         var first = _viewModel.PreviewTable.Count > 0 ? _viewModel.PreviewTable[0] : null;
-        if (first == null) return;
+        if (first == null)
+        {
+            return;
+        }
 
         if (first is IDictionary<string, object> dict)
         {
@@ -149,21 +158,28 @@ public partial class ImportDialogWindow : Window
         public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
         {
             if (parameter is not string key)
+            {
                 return null;
+            }
 
             if (value is IDictionary<string, object> dict)
             {
                 if (dict.TryGetValue(key, out var val))
                 {
-                    if (val == null) return null;
+                    if (val == null)
+                    {
+                        return null;
+                    }
 
                     // Format DateTime specially
                     if (val is DateTime dt)
                     {
-                        return dt.ToString("dd.MM.yyyy");
+                        var dtResult = dt.ToString("dd.MM.yyyy");
+                        return dtResult;
                     }
 
-                    return val.ToString();
+                    var strResult = val.ToString();
+                    return strResult;
                 }
             }
 
@@ -175,7 +191,10 @@ public partial class ImportDialogWindow : Window
                 {
                     var dic = value as IDictionary<string, object>;
                     if (dic != null && dic.TryGetValue(k, out var v))
-                        return v?.ToString();
+                    {
+                        var vResult = v?.ToString();
+                        return vResult;
+                    }
                 }
                 catch { }
             }


### PR DESCRIPTION
1. No expression-bodied methods — every method uses { } block body; only get => / set => property accessors are allowed.
2. Return via local variable — all returns that involved method calls, operators, or object creation now extract to var result before return.
3. Braces in all control flow — every if/else/for/foreach body is on its own line wrapped in { }, including continue/break guards.

Also includes: Icons.axaml resource dictionary added to App.axaml.