### PR TITLE
build: upgrade Avalonia from 11.3.12 to 12.0.4

### DIFF
--- a/Mil.MVVM.Common/Mil.MVVM.Common.csproj
+++ b/Mil.MVVM.Common/Mil.MVVM.Common.csproj
@@ -6,8 +6,5 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.12" />
-  </ItemGroup>
 
 </Project>

--- a/Mil.Paperwork.Common/Mil.Paperwork.Common.csproj
+++ b/Mil.Paperwork.Common/Mil.Paperwork.Common.csproj
@@ -6,9 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.12" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Mil.MVVM.Common\Mil.MVVM.Common.csproj" />

--- a/Mil.Paperwork.Domain/Mil.Paperwork.Domain.csproj
+++ b/Mil.Paperwork.Domain/Mil.Paperwork.Domain.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.12" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.1.0" />
     <PackageReference Include="EPPlus" Version="7.6.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />

--- a/Mil.Paperwork.Infrastructure/Mil.Paperwork.Infrastructure.csproj
+++ b/Mil.Paperwork.Infrastructure/Mil.Paperwork.Infrastructure.csproj
@@ -13,7 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.12" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.3" />
   </ItemGroup>

--- a/Mil.Paperwork.UI/App.axaml.cs
+++ b/Mil.Paperwork.UI/App.axaml.cs
@@ -1,10 +1,8 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Data.Core.Plugins;
 using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.DependencyInjection;
 using System.Globalization;
-using System.Linq;
 using System.Threading;
 using System;
 using Mil.Paperwork.UI.Configuration;
@@ -50,8 +48,6 @@ namespace Mil.Paperwork.UI
 
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
-                DisableAvaloniaDataAnnotationValidation();
-
                 var mainWindow = new MainWindow();
                 var mainWindowViewModel = provider.GetRequiredService<MainWindowViewModel>();
                 mainWindow.DataContext = mainWindowViewModel;
@@ -60,15 +56,6 @@ namespace Mil.Paperwork.UI
             }
 
             base.OnFrameworkInitializationCompleted();
-        }
-
-        private void DisableAvaloniaDataAnnotationValidation()
-        {
-            var dataValidationPluginsToRemove =
-                BindingPlugins.DataValidators.OfType<DataAnnotationsValidationPlugin>().ToArray();
-
-            foreach (var plugin in dataValidationPluginsToRemove)
-                BindingPlugins.DataValidators.Remove(plugin);
         }
 
         private void SetCurrentCulture()

--- a/Mil.Paperwork.UI/Mil.Paperwork.UI.csproj
+++ b/Mil.Paperwork.UI/Mil.Paperwork.UI.csproj
@@ -28,14 +28,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.12" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.1.1" />
-    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="11.3.9.5" />
+    <PackageReference Include="Avalonia" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.4" />
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.2" />
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Update Avalonia, Desktop, Themes.Fluent, Fonts.Inter to 12.0.4
- Update Avalonia.Controls.DataGrid to 12.0.0
- Update AvaloniaUI.DiagnosticsSupport to 2.2.2
- Update Xaml.Behaviors.Avalonia to 12.0.0.1
- Remove unused Avalonia.Diagnostics from non-UI projects (no v12 release)
- Remove DisableAvaloniaDataAnnotationValidation (BindingPlugins became internal in v12; method was unused — no DataAnnotations attributes in VMs)