### PR TITLE
fix: restrict BattleOrderDate and EventDate selection to not exceed R…

### DIFF
--- a/Mil.Paperwork.UI/ViewModels/Reports/WriteOffOrderViewModel.cs
+++ b/Mil.Paperwork.UI/ViewModels/Reports/WriteOffOrderViewModel.cs
@@ -80,6 +80,7 @@ namespace Mil.Paperwork.UI.ViewModels.Reports
             {
                 if (SetProperty(ref _reportDate, value))
                 {
+                    OnPropertyChanged(nameof(MaxDate));
                     if (BattleOrderDate > _reportDate)
                     {
                         BattleOrderDate = _reportDate;
@@ -92,10 +93,30 @@ namespace Mil.Paperwork.UI.ViewModels.Reports
             }
         }
 
-        public DateTime EventDate { get => _eventDate; set => SetProperty(ref _eventDate, value); }
+        public DateTime? MaxDate => _reportDate;
+
+        public DateTime EventDate
+        {
+            get => _eventDate;
+            set
+            {
+                var clamped = value > _reportDate ? _reportDate : value;
+                SetProperty(ref _eventDate, clamped);
+            }
+        }
+
         public string EventTime { get => _eventTime; set => SetProperty(ref _eventTime, value); }
         public string BattleOrder { get => _battleOrder; set => SetProperty(ref _battleOrder, value); }
-        public DateTime BattleOrderDate { get => _battleOrderDate; set => SetProperty(ref _battleOrderDate, value); }
+
+        public DateTime BattleOrderDate
+        {
+            get => _battleOrderDate;
+            set
+            {
+                var clamped = value > _reportDate ? _reportDate : value;
+                SetProperty(ref _battleOrderDate, clamped);
+            }
+        }
         public string BattleOrderLocation { get => _battleOrderLocation; set => SetProperty(ref _battleOrderLocation, value); }
         public string WhatHappened { get => _whatHappened; set => SetProperty(ref _whatHappened, value); }
         public string MilUnitApproval { get => _milUnitApproval; set => SetProperty(ref _milUnitApproval, value); }

--- a/Mil.Paperwork.UI/Views/HomePageView.axaml
+++ b/Mil.Paperwork.UI/Views/HomePageView.axaml
@@ -64,14 +64,14 @@
 			<Button Content="Довідник осіб"
 					Command="{Binding OpenPeopleDictionaryCommand}" />
 
+			<Button Content="Довідник служб"
+					Command="{Binding OpenServicesDictionaryCommand}" />
+
 			<Button Content="Конфігурація звітів"
 					Command="{Binding OpenReportConfigurationCommand}" />
 
 			<Button Content="Конфігурація Комісій"
 					Command="{Binding OpenCommissionsConfigurationCommand}" />
-
-			<Button Content="Довідник служб"
-					Command="{Binding OpenServicesDictionaryCommand}" />
 
 		</StackPanel>
 	</Grid>

--- a/Mil.Paperwork.UI/Views/Reports/WriteOffOrderView.axaml
+++ b/Mil.Paperwork.UI/Views/Reports/WriteOffOrderView.axaml
@@ -79,8 +79,9 @@
                             <TextBlock Grid.Row="4" Grid.Column="2" Text="Дата:"
                                        VerticalAlignment="Center" Margin="0,0,6,0"/>
                             <CalendarDatePicker Grid.Row="4" Grid.Column="3"
-                                                DisplayDateEnd="{Binding ReportDate, UpdateSourceTrigger=PropertyChanged}"
-                                                SelectedDate="{Binding BattleOrderDate}"
+                                                DisplayDateEnd="{Binding MaxDate}"
+                                                SelectedDate="{Binding BattleOrderDate, UpdateSourceTrigger=PropertyChanged}"
+                                                SelectedDateChanged="OnRestrictedDateChanged"
                                                 HorizontalAlignment="Stretch"
                                                 Margin="0,2"/>
 
@@ -95,8 +96,9 @@
                             <TextBlock Grid.Row="6" Grid.Column="0" Text="Дата події:"
                                        VerticalAlignment="Center" Margin="0,0,6,0"/>
                             <CalendarDatePicker Grid.Row="6" Grid.Column="1"
-                                                DisplayDateEnd="{Binding ReportDate, UpdateSourceTrigger=PropertyChanged}"
-                                                SelectedDate="{Binding EventDate}"
+                                                DisplayDateEnd="{Binding MaxDate}"
+                                                SelectedDate="{Binding EventDate, UpdateSourceTrigger=PropertyChanged}"
+                                                SelectedDateChanged="OnRestrictedDateChanged"
                                                 HorizontalAlignment="Stretch"
                                                 Margin="0,2,8,2"/>
                             <TextBlock Grid.Row="6" Grid.Column="2" Text="Час:"

--- a/Mil.Paperwork.UI/Views/Reports/WriteOffOrderView.axaml.cs
+++ b/Mil.Paperwork.UI/Views/Reports/WriteOffOrderView.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Mil.Paperwork.UI.ViewModels.Reports;
 
 namespace Mil.Paperwork.UI.Views.Reports;
 
@@ -7,5 +8,23 @@ public partial class WriteOffOrderView : UserControl
     public WriteOffOrderView()
     {
         InitializeComponent();
+    }
+
+    private void OnRestrictedDateChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (DataContext is not WriteOffOrderViewModel vm)
+        {
+            return;
+        }
+
+        if (sender is not CalendarDatePicker picker)
+        {
+            return;
+        }
+
+        if (picker.SelectedDate.HasValue && picker.SelectedDate.Value.Date > vm.ReportDate.Date)
+        {
+            picker.SelectedDate = vm.ReportDate;
+        }
     }
 }


### PR DESCRIPTION
…eportDate

- Add MaxDate (DateTime?) property to expose ReportDate for correct DisplayDateEnd binding
- Add SelectedDateChanged code-behind handler to reset picker if user selects a date beyond ReportDate
- Reorder HomePageView buttons: move Довідник служб above Конфігурація звітів