### PR TITLE
fix: skip single-instance mutex in Avalonia design mode

### DIFF
--- a/Mil.Paperwork.UI/App.axaml.cs
+++ b/Mil.Paperwork.UI/App.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,13 +28,15 @@ namespace Mil.Paperwork.UI
 
         public override void OnFrameworkInitializationCompleted()
         {
-            // single-instance guard
-            _mutex = new Mutex(true, AppName, out var createdNew);
-            if (!createdNew)
+            if (!Design.IsDesignMode)
             {
-                // another instance exists -> exit
-                Environment.Exit(0);
-                return;
+                // single-instance guard
+                _mutex = new Mutex(true, AppName, out var createdNew);
+                if (!createdNew)
+                {
+                    Environment.Exit(0);
+                    return;
+                }
             }
 
             SetCurrentCulture();

--- a/Mil.Paperwork.UI/Views/Dictionaries/ServicesDictionaryView.axaml
+++ b/Mil.Paperwork.UI/Views/Dictionaries/ServicesDictionaryView.axaml
@@ -52,17 +52,17 @@
                 <TextBlock Grid.Row="0" Grid.Column="0" Text="Назва (називний відмінок):" VerticalAlignment="Center"/>
                 <TextBox   Grid.Row="0" Grid.Column="2"
                            Text="{Binding SelectedService.NominativeName}"
-                           Watermark="Наприклад: Служба зв'язку"/>
+                           PlaceholderText="Наприклад: Служба зв'язку"/>
 
                 <TextBlock Grid.Row="2" Grid.Column="0" Text="Назва (родовий відмінок):" VerticalAlignment="Center"/>
                 <TextBox   Grid.Row="2" Grid.Column="2"
                            Text="{Binding SelectedService.GenitiveName}"
-                           Watermark="Наприклад: служби зв'язку"/>
+                           PlaceholderText="Наприклад: служби зв'язку"/>
 
                 <TextBlock Grid.Row="4" Grid.Column="0" Text="Коротка назва:" VerticalAlignment="Center"/>
                 <TextBox   Grid.Row="4" Grid.Column="2"
                            Text="{Binding SelectedService.ShortName}"
-                           Watermark="Наприклад: зв'язок"/>
+                           PlaceholderText="Наприклад: зв'язок"/>
 
                 <TextBlock Grid.Row="6" Grid.Column="0" Text="Тип майна*:" VerticalAlignment="Center"/>
                 <ComboBox  Grid.Row="6" Grid.Column="2"
@@ -84,12 +84,12 @@
                 <TextBlock Grid.Row="2" Grid.Column="4" Text="Посада:" VerticalAlignment="Center"/>
                 <TextBox   Grid.Row="2" Grid.Column="6"
                            Text="{Binding SelectedService.HeadPosition}"
-                           Watermark="Наприклад: Начальник служби зв'язку"/>
+                           PlaceholderText="Наприклад: Начальник служби зв'язку"/>
 
                 <TextBlock Grid.Row="4" Grid.Column="4" Text="Звання:" VerticalAlignment="Center"/>
                 <TextBox   Grid.Row="4" Grid.Column="6"
                            Text="{Binding SelectedService.HeadRank}"
-                           Watermark="Наприклад: підполковник"/>
+                           PlaceholderText="Наприклад: підполковник"/>
 
             </Grid>
         </Border>

--- a/Mil.Paperwork.UI/Views/Reports/WriteOffOrderView.axaml
+++ b/Mil.Paperwork.UI/Views/Reports/WriteOffOrderView.axaml
@@ -52,7 +52,7 @@
                                        VerticalAlignment="Center" Margin="0,0,6,0"/>
                             <TextBox   Grid.Row="2" Grid.Column="1"
                                        Text="{Binding ReporterRank, UpdateSourceTrigger=PropertyChanged}"
-                                       Watermark="родовий відмінок"
+                                       PlaceholderText="родовий відмінок"
                                        Margin="0,2,8,2"/>
 
                             <!-- Підрозділ -->
@@ -67,7 +67,7 @@
                                        VerticalAlignment="Center" Margin="0,0,6,0"/>
                             <TextBox   Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3"
                                        Text="{Binding ReporterName, UpdateSourceTrigger=PropertyChanged}"
-                                       Watermark="родовий відмінок"
+                                       PlaceholderText="родовий відмінок"
                                        Margin="0,2"/>
 
                             <!-- Бойовий наказ № + Дата -->
@@ -106,7 +106,7 @@
                             <MaskedTextBox Grid.Row="6" Grid.Column="3"
                                            Mask="00:00"
                                            Text="{Binding EventTime}"
-                                           Watermark="гг:хх"
+                                           PlaceholderText="гг:хх"
                                            HorizontalAlignment="Stretch"
                                            VerticalAlignment="Center"
                                            Margin="0,2"/>
@@ -206,7 +206,7 @@
                                         <DataGridTemplateColumn.CellTemplate>
                                             <DataTemplate>
                                                 <TextBox Text="{Binding Rank, UpdateSourceTrigger=PropertyChanged}"
-                                                         Watermark="молодший сержант"
+                                                         PlaceholderText="молодший сержант"
                                                          BorderThickness="0"
                                                          VerticalAlignment="Center"/>
                                             </DataTemplate>
@@ -217,7 +217,7 @@
                                         <DataGridTemplateColumn.CellTemplate>
                                             <DataTemplate>
                                                 <TextBox Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}"
-                                                         Watermark="УДАЛОВ Володимир Віталійович"
+                                                         PlaceholderText="УДАЛОВ Володимир Віталійович"
                                                          BorderThickness="0"
                                                          VerticalAlignment="Center"/>
                                             </DataTemplate>
@@ -337,10 +337,10 @@
 
                                                     <TextBox Grid.Row="4" Grid.ColumnSpan="3"
                                                              Text="{Binding NewServiceNominative, UpdateSourceTrigger=PropertyChanged}"
-                                                             Watermark="Назва (називний відмінок): напр. Інженерна служба"/>
+                                                             PlaceholderText="Назва (називний відмінок): напр. Інженерна служба"/>
                                                     <TextBox Grid.Row="6" Grid.ColumnSpan="3"
                                                              Text="{Binding NewServiceGenitive, UpdateSourceTrigger=PropertyChanged}"
-                                                             Watermark="Назва (родовий відмінок): напр. інженерної служби"/>
+                                                             PlaceholderText="Назва (родовий відмінок): напр. інженерної служби"/>
 
                                                     <StackPanel Grid.Row="8" Grid.ColumnSpan="3" 
                                                                 Orientation="Horizontal" Spacing="6">


### PR DESCRIPTION
The Avalonia XAML previewer in VS runs App.OnFrameworkInitializationCompleted() in a background process, which was acquiring the named mutex. Any subsequent launch of the release exe found the mutex taken and exited silently (exit 0).

Guard the mutex block with Design.IsDesignMode so the previewer no longer interferes with running the packaged app.

Also replace deprecated TextBox.Watermark with PlaceholderText (AVLN5001) in WriteOffOrderView and ServicesDictionaryView.